### PR TITLE
Update _variables.scss

### DIFF
--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -31,7 +31,7 @@ $heading-spacing: 0.5rem !default;
 $section-spacing: 2rem !default;
 $sidebar-width: 18rem !default;
 
-$large-breakpoint: 48rem !default;
+$large-breakpoint: 49rem !default;
 $large-font-size: 1.25rem !default;
 
 $box-shadow-size: 1px !default;


### PR DESCRIPTION
Changed the $large-breakpoint from 48rem (exactly the width of an iPad) to 49. This keeps the page from flipping out (pun intended) when in portrait orientation.